### PR TITLE
Correct issue with ID on show-hangouts

### DIFF
--- a/assets/scripts/templates/show-hangouts.handlebars
+++ b/assets/scripts/templates/show-hangouts.handlebars
@@ -26,7 +26,7 @@
       <!-- <a class="event-button" href="#" data-toggle="popover" data-trigger="focus" data-placement="top" data-toggle="popover" title="Attendees"> -->
       <div class="btn-group">
         <button data-id="{{hangout._id}}" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" class="btn btn-sm btn-outline-dark btn-show-attendees show-attend-button dropdown-toggle">Show Attendees</button>
-        <div class="dropdown-menu" id="#{{hangout._id}}">
+        <div class="dropdown-menu" id="{{hangout._id}}">
         </div>
       </div>
       <!-- </a> -->


### PR DESCRIPTION
ID on show-hangouts handlebars for dropdown menus had an extra '#'
preventing .html() command in Ui.js from functioning