### PR TITLE
Fix show attendees

### DIFF
--- a/assets/scripts/hangout/events.js
+++ b/assets/scripts/hangout/events.js
@@ -78,7 +78,7 @@ const addHangoutEventHandlers = function () {
   $('.temporary-hangout-holder').on('click', '.delete-button', onDeleteHangout)
   $('.temporary-hangout-holder').on('click', '.attend-button', onAttend)
   $('.temporary-hangout-holder').on('submit', '.edit-hangout', onUpdateHangout)
-  $('.temporary-hangout-holder').on('click', '.show-attend-button', onGetAttendance)
+  $('.temporary-hangout-holder').on('focus', '.show-attend-button', onGetAttendance)
 }
 
 module.exports = {


### PR DESCRIPTION
--Changed click handler on show attendees to use focus instead of
click. This was needed due to function only firing once on click
when it needed to fire on every subsequent click if other changes
were made on the page.