### PR TITLE
Fix attendees dropdown

### DIFF
--- a/assets/scripts/templates/show-attendees.handlebars
+++ b/assets/scripts/templates/show-attendees.handlebars
@@ -1,4 +1,4 @@
 {{#each attendees as |attendee|}}
   <!-- <li class="list-group-item">{{attendee.owner.email}}</li> -->
-  <a class="dropdown-item" href="#"> {{attendee.owner.email}} </a>
+  <p class="dropdown-item"> {{attendee.owner.email}} </p>
 {{/each}}


### PR DESCRIPTION
--Changed handlebars items in attendees dropdown from anchors to
paragraphs. This fixes an issue where a user would click in the
dropdown and the page would jump to the top.